### PR TITLE
Fix RISC OS FS enumeration terminating early.

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -13388,8 +13388,9 @@ ScandirIterator_iternext(ScandirIterator *iterator)
 {
     PyObject *entry;
 
-    /* No buffer or already at end */
-    if (iterator->gbpb_buffer == NULL || iterator->gbpb_index == -1)
+    /* No buffer or already at end, and have no files left to return */
+    if (iterator->gbpb_buffer == NULL ||
+        (iterator->gbpb_count == 0 && iterator->gbpb_index == -1))
         return NULL;
 
     /* Do we need to read some entries from the FS? */


### PR DESCRIPTION
When enumerating files through the OS_GBPB interface there may be
multiple files returned in the final block of files returned by
the OS_GBPB enumeration of the files. That is, the returned 'next
context' may be -1 and the number of objects read be greater than 0.

In the words of the PRM:
  "R4 contains the value which should be used on the next call (to read
  more names), or -1 if there are no more names after the ones read by
  this call."

The enumerator was terminating when the context indicated there were
no further entries, but there are still entries in its buffer to be
returned.

This change replaces the single check on the context, with a check that
the number of entries remaining in the internal buffer is 0 as well.
